### PR TITLE
Introduces optional lowpass threshold for WorldPop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ target/scala-2.11/hot-osm-population-assembly.jar \
 --worldpop file:${WORKDIR}/WorldPop/BWA15v4.tif \
 --qatiles ${WORKDIR}/mbtiles/botswana.mbtiles \
 --training ${CURDIR}/data/botswana-training-set.json \
---model ${WORKDIR}/models/botswana-regression
+--model ${WORKDIR}/models/botswana-regression \
+--lowpass 0.1
 
 predict: ${ASSEMBLY_JAR}
 	spark-submit --master "local[*]" --driver-memory 4G \
@@ -40,4 +41,5 @@ target/scala-2.11/hot-osm-population-assembly.jar \
 --worldpop file:${WORKDIR}/WorldPop/BWA15v4.tif \
 --qatiles ${WORKDIR}/mbtiles/botswana.mbtiles \
 --model ${WORKDIR}/models/botswana-regression \
---output ${WORKDIR}/botswana.json
+--output ${WORKDIR}/botswana.json \
+--lowpass 0.1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The arguments appearing after the JAR are specific to the application:
 `qatiles`: Path to MapBox QA `.mbtiles` file for the country, must be local.
 `model`: Path to save/load model directory, is  must be local.
 `output`: Path to generate prediction JSON output, must be local.
-
+`lowpass`: Threshold value for WorldPop. WorldPop cells values smaller than threshold will be set to `0.0`.
 
 For development the train and predict commands can are scripted through the `Makefile`:
 

--- a/src/main/scala/LabeledTrainApp.scala
+++ b/src/main/scala/LabeledTrainApp.scala
@@ -45,10 +45,11 @@ object LabeledTrainApp extends CommandApp(
     val worldPopUriO = Opts.option[String]("worldpop", help = "URI of WorldPop raster for a country")
     val qaTilesPathO = Opts.option[String]("qatiles", help = "Path to country QA VectorTiles mbtiles file")
     val modelUriO    = Opts.option[String]("model", help = "URI for model to be saved")
+    val lowPassO     = Opts.option[Double]("lowpass", help = "Lowpass threshold for WorldPop values").orNone
 
     (
-      countryCodeO, worldPopUriO, qaTilesPathO, modelUriO, trainingPathO
-    ).mapN { (country, worldPopUri, qaTilesPath, modelUri, trainingPath) =>
+      countryCodeO, worldPopUriO, qaTilesPathO, modelUriO, trainingPathO, lowPassO
+    ).mapN { (country, worldPopUri, qaTilesPath, modelUri, trainingPath, lowPass) =>
 
       implicit val spark: SparkSession = SparkSession.builder().
         appName("WorldPop-OSM-Train").
@@ -76,7 +77,7 @@ object LabeledTrainApp extends CommandApp(
       println(s"Using ${trainingSet.length} training polygons")
 
       // read WorldPop in WebMercator Zoom 12
-      val pop: RasterFrame = WorldPop.rasterFrame(worldPopUri, "pop", masks = trainingSet)
+      val pop: RasterFrame = WorldPop.rasterFrame(worldPopUri, "pop", masks = trainingSet, lowPass = lowPass)
 
       // Add OSM building footprints as rasterized tile column
       val popWithOsm: RasterFrame = OSM.withBuildingsRF(pop, qaTilesPath, country, "osm")

--- a/src/main/scala/WorldPop.scala
+++ b/src/main/scala/WorldPop.scala
@@ -58,12 +58,24 @@ object WorldPop {
      columnName: String,
      layout: LayoutDefinition = ZoomedLayoutScheme(WebMercator, 256).levelForZoom(12).layout,
      crs: CRS = WebMercator,
-     masks: Traversable[Polygon] = Array.empty[Polygon]
+     masks: Traversable[Polygon] = Array.empty[Polygon],
+     lowPass: Option[Double] = None
    )(implicit spark: SparkSession): RasterFrame = {
     val (popLatLngRdd, md) = WorldPop.readBufferedTiles(file)(spark.sparkContext)
 
+    val filtered = lowPass match {
+      case Some(threshold) =>
+        popLatLngRdd.mapValues{ bt =>
+          val lowPassTile = bt.tile.mapDouble { d =>
+            if (isData(d) && d < threshold) Double.NaN else d
+          }
+          BufferedTile(lowPassTile, bt.targetArea)
+        }
+      case None => popLatLngRdd
+    }
+
     val popRdd: TileLayerRDD[SpatialKey] = TileRDDReproject(
-      bufferedTiles = popLatLngRdd,
+      bufferedTiles = filtered,
       metadata = md,
       destCrs = crs,
       targetLayout = Right(layout),

--- a/src/main/scala/WorldPop.scala
+++ b/src/main/scala/WorldPop.scala
@@ -67,7 +67,7 @@ object WorldPop {
       case Some(threshold) =>
         popLatLngRdd.mapValues{ bt =>
           val lowPassTile = bt.tile.mapDouble { d =>
-            if (isData(d) && d < threshold) Double.NaN else d
+            if (isData(d) && d < threshold) 0 else d
           }
           BufferedTile(lowPassTile, bt.targetArea)
         }


### PR DESCRIPTION
An attempt to deal with "smeared" population cells in WorldPop that contain uniform values of "0.001.." etc.

Because we sum all that population when reprojecting and downsampling these values can add up to hundreds in no-pop tiles. At the moment its unclear if this pre-processing step is actually beneficial.